### PR TITLE
Install newer coffee for using beautiful grammer

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "nyamadori <nyamadorig@gmail.com>",
   "description": "A simple helpful robot for your Company",
   "dependencies": {
+    "coffee-script": "^1.10.0",
     "hubot": "^2.18.0",
     "hubot-diagnostics": "0.0.1",
     "hubot-google-images": "^0.2.6",


### PR DESCRIPTION
# Background

From CoffeeScript 1.7.0, it can use new beautiful grammer as follows:

> Leading . now closes all open calls, allowing for simpler chaining syntax.

``` coffee
$ 'body'
.click (e) ->
  $ '.box'
  .fadeIn 'fast'
  .addClass '.active'
.css 'background', 'white'
```

However, Hubot is using CoffeeScript 1.6.3, because the libraries of Hubot depends on that version. So Hubot programs can't use the grammer, and Hubot shouldn't upgrade CoffeeScript.

See: https://github.com/github/hubot/issues/1112
# Solution

Node.js load scripts (using `require`) near the current execution path: https://nodejs.org/api/modules.html#modules_loading_from_node_modules_folders

So its solution is install newer CoffeeScript on the root of this repository: `npm install --save coffee-script`, and Hubot will use the newer CoffeeScript!
